### PR TITLE
Fixed Cue sheet possiton to be in MM:SS:FF

### DIFF
--- a/src/processor/mp3-with-cue.ts
+++ b/src/processor/mp3-with-cue.ts
@@ -130,7 +130,7 @@ export async function processMP3Files(spine: Spine, meta: MP3Meta, decode: boole
     processed.cueContent += `
   TRACK ${zeroPad(idx + 1)} AUDIO
     TITLE "${entry.title}"
-    INDEX 01 ${toTime(false, Math.round(start))}`;
+    INDEX 01 ${toTime(false, Math.round(start))}:00`;
     await updateTask(chapterTask, "Completed");
   }
 

--- a/tests/mp3withcue.test.ts
+++ b/tests/mp3withcue.test.ts
@@ -77,15 +77,15 @@ describe("chapter processing", () => {
 FILE "Book Title.mp3" MP3
   TRACK 01 AUDIO
     TITLE "Chapter 1"
-    INDEX 01 00:00
+    INDEX 01 00:00:00
   TRACK 02 AUDIO
     TITLE "Chapter 2"
-    INDEX 01 02:30
+    INDEX 01 02:30:00
   TRACK 03 AUDIO
     TITLE "Chapter 3"
-    INDEX 01 02:55
+    INDEX 01 02:55:00
   TRACK 04 AUDIO
     TITLE "Chapter 4"
-    INDEX 01 04:10`);
+    INDEX 01 04:10:00`);
   });
 });


### PR DESCRIPTION
Now when it creates the Cue Sheet it adds :00 as the Frame since mp3 files don't have a frame.  This puts the Index position into the proper format of MM:SS:FF.  